### PR TITLE
Replace percent formatting with format strings

### DIFF
--- a/anf/data/python/3rdparty/lib/pymodule.mk
+++ b/anf/data/python/3rdparty/lib/pymodule.mk
@@ -25,7 +25,7 @@ EASY_INSTALL_ARGS  = -d $(ANF_PYTHON_LIB_DIR) -s $(ANF_PYTHON_SCRIPTS_DIR) -N
 EASY_INSTALL_ARGS += $(EXTRA_EASY_INSTALL_ARGS)
 
 # Generate the name of the EGGFILE that will be created by the module.
-EGGFILE = $(shell $(PYTHON_EXECUTABLE) -c 'import sys; print "%s-%s-py%s.egg" % ("'$(MODULE_NAME)'", "'$(MODULE_VERSION)'", sys.version[:3])')
+EGGFILE = $(shell $(PYTHON_EXECUTABLE) -c 'import sys; print("{}-{}-py{}.egg".format("'$(MODULE_NAME)'", "'$(MODULE_VERSION)'", sys.version[:3]))')
 
 ###
 ### Targets

--- a/antelope/data/python/readline/GNUmakefile
+++ b/antelope/data/python/readline/GNUmakefile
@@ -13,7 +13,7 @@ EASY_INSTALL       = $(PYTHON_EXECUTABLE) -m easy_install
 EASY_INSTALL_ARGS  = -N
 
 # Generate the name of the EGGFILE that will be created by the module.
-EGGFILE = $(shell $(PYTHON_EXECUTABLE) -c 'import sys; print "%s-%s-py%s.egg" % ("'$(MODULE_NAME)'", "'$(MODULE_VERSION)'", sys.version[:3])')
+EGGFILE = $(shell $(PYTHON_EXECUTABLE) -c 'import sys; print("{}-{}-py{}.egg".format("'$(MODULE_NAME)'", "'$(MODULE_VERSION)'", sys.version[:3]))')
 
 ###
 ### Targets


### PR DESCRIPTION
Python 2 to 3 migration requires format strings instead of printf style
percent sign replacment.

This fixes initial build problems with 3rd party python modules that are part of the typical ANF overlay.