### PR TITLE
Convert dbwfserver_ta_setup to use a parameter file

### DIFF
--- a/anf/bin/utility/dbwfserver_ta_setup/Makefile
+++ b/anf/bin/utility/dbwfserver_ta_setup/Makefile
@@ -1,6 +1,6 @@
 MAN1=dbwfserver_ta_setup.1
-BIN=dbwfserver_ta_setup 
-
+BIN=dbwfserver_ta_setup
+PF=dbwfserver_ta_setup.pf
 
 include $(ANFMAKE)
 

--- a/anf/bin/utility/dbwfserver_ta_setup/dbwfserver_ta_setup.pf
+++ b/anf/bin/utility/dbwfserver_ta_setup/dbwfserver_ta_setup.pf
@@ -1,0 +1,60 @@
+# Directory containing the dbwfserver process
+rtsystem_directory      /export/home/rt/rtsystems/dbwfserver
+
+# Paths to various databases
+# Each must contain the following subkeys:
+# - db
+# - temp
+# - new
+database_paths &Arr{
+    # AOC testing. TESTING SYSTEMS ONLY
+    'aoc'           &Arr{
+        'db'   "db/dbwfserver_aoc_test"
+        'temp' "db/dbwfserver_temp"
+        'new'  "db/dbwfserver_aoc_test"
+    }
+    # TA Seismic database
+    'ta'            &Arr{
+        'db'   "db/dbwfserver_usarray"
+        'temp' "db/dbwfserver_temp"
+        'new'  "db/dbwfserver_usarray"
+    }
+    # TA SOH database
+    'soh'           &Arr{
+        'db'   "db/dbwfserver_status"
+        'temp' "db/dbwfserver_temp"
+        'new'  "db/dbwfserver_status"
+    }
+    # TA INFRAMET database
+    'inframet'      &Arr{
+        'db'   "db/dbwfserver_inframet"
+        'temp' "db/dbwfserver_tmp"
+        'new'  "db/dbwfserver_inframet"
+    }
+    # ANZA database
+    'anza'          &Arr{
+        'db'   "db/dbwfserver_anza"
+        'temp' "db/dbwfserver_tmp"
+        'new'  "db/dbwfserver_anza"
+    }
+    # CEUSN database
+    'ceusn'         &Arr{
+        'db'   "db/dbwfserver_ceusn"
+        'temp' "db/dbwfserver_tmp"
+        'new'  "db/dbwfserver_ceusn"
+    }
+    # CEUSN INFRAMET database
+    'ceusninframet' &Arr{
+        'db'   "db/dbwfserver_ceusn_inframet"
+        'temp' "db/dbwfserver_tmp"
+        'new'  "db/dbwfserver_ceusn_inframet"
+    }
+    # CEUSN SOH database
+    'ceusnsoh'      &Arr{
+        'db'   "db/dbwfserver_ceusn_soh"
+        'temp' "db/dbwfserver_tmp"
+        'new'  "db/dbwfserver_ceusn_soh"
+    }
+}
+
+pf_revision_time 1579029286

--- a/anf/bin/utility/dbwfserver_ta_setup/dbwfserver_ta_setup.pf
+++ b/anf/bin/utility/dbwfserver_ta_setup/dbwfserver_ta_setup.pf
@@ -1,59 +1,18 @@
 # Directory containing the dbwfserver process
 rtsystem_directory      /export/home/rt/rtsystems/dbwfserver
 
+
 # Paths to various databases
 # Each must contain the following subkeys:
 # - db
 # - temp
 # - new
 database_paths &Arr{
-    # AOC testing. TESTING SYSTEMS ONLY
-    'aoc'           &Arr{
-        'db'   "db/dbwfserver_aoc_test"
-        'temp' "db/dbwfserver_temp"
-        'new'  "db/dbwfserver_aoc_test"
-    }
-    # TA Seismic database
-    'ta'            &Arr{
-        'db'   "db/dbwfserver_usarray"
-        'temp' "db/dbwfserver_temp"
-        'new'  "db/dbwfserver_usarray"
-    }
-    # TA SOH database
-    'soh'           &Arr{
-        'db'   "db/dbwfserver_status"
-        'temp' "db/dbwfserver_temp"
-        'new'  "db/dbwfserver_status"
-    }
-    # TA INFRAMET database
-    'inframet'      &Arr{
-        'db'   "db/dbwfserver_inframet"
-        'temp' "db/dbwfserver_tmp"
-        'new'  "db/dbwfserver_inframet"
-    }
-    # ANZA database
-    'anza'          &Arr{
-        'db'   "db/dbwfserver_anza"
-        'temp' "db/dbwfserver_tmp"
-        'new'  "db/dbwfserver_anza"
-    }
-    # CEUSN database
-    'ceusn'         &Arr{
-        'db'   "db/dbwfserver_ceusn"
-        'temp' "db/dbwfserver_tmp"
-        'new'  "db/dbwfserver_ceusn"
-    }
-    # CEUSN INFRAMET database
-    'ceusninframet' &Arr{
-        'db'   "db/dbwfserver_ceusn_inframet"
-        'temp' "db/dbwfserver_tmp"
-        'new'  "db/dbwfserver_ceusn_inframet"
-    }
-    # CEUSN SOH database
-    'ceusnsoh'      &Arr{
-        'db'   "db/dbwfserver_ceusn_soh"
-        'temp' "db/dbwfserver_tmp"
-        'new'  "db/dbwfserver_ceusn_soh"
+    # ANZA demo database
+    demo &Arr{
+        db   /opt/antelope/data/db/demo/demo
+        temp db/dbwfserver_temp
+        new  db/dbwfserver_anza_demo
     }
 }
 

--- a/anf/bin/utility/dbwfserver_ta_setup/dbwfserver_ta_setup.xpl
+++ b/anf/bin/utility/dbwfserver_ta_setup/dbwfserver_ta_setup.xpl
@@ -122,7 +122,7 @@ sub remove_table_temp_file{
     my $table = shift;
     our $options;
 
-    elog_notify("\tRemove temp file: [$table]");
+    elog_notify("Remove temp file: [$table]");
     return 0 if $options{'n'};
 
     if ( -f $table ){
@@ -135,10 +135,10 @@ sub my_run{
     my $cmd = shift ;
     our %options;
 
-    elog_notify("\tRunning cmd: [$cmd]");
+    elog_notify("my_run: Running cmd: [$cmd]");
     return if $options{'n'};
 
-    system($cmd) == 0 or log_die("ERROR in system call: [$cmd]");
+    (system($cmd) == 0) or log_die("ERROR in system call: [$cmd]");
 
     if ($? == -1){
         log_die("failed to execute: [$cmd] => $!");
@@ -148,7 +148,7 @@ sub my_run{
             ($? & 128) ? 'with' : 'without');
     }
     else {
-        elog_notify("\t\tchild exited with value %d", $? >> 8);
+        elog_notify(sprintf("child exited with value %d", $? >> 8));
     }
     return;
 }
@@ -228,7 +228,7 @@ sub main {
         #
         # Clean old temp files
         #
-        elog_notify("\tClean temp tables for $d") ;
+        elog_notify("Clean temp tables for $d") ;
 
         remove_table_temp_file( "${d_temp}.lastid" ) ;
         remove_table_temp_file( "${d_temp}.sitechan" ) ;
@@ -236,13 +236,13 @@ sub main {
         #
         # Build sitechan table
         #
-        elog_notify("$dbadd -a $d_db.wfdisc $d_temp.sitechan") ;
-        my_run("$dbadd -a $d_db.wfdisc $d_temp.sitechan  >& /dev/null") unless $options{'n'} ;
+        elog_notify("Running $dbadd -a $d_db.wfdisc $d_temp.sitechan") ;
+        my_run("$dbadd -a $d_db.wfdisc $d_temp.sitechan") unless $options{'n'} ;
 
         #
         # Move sitechan table
         #
-        elog_notify("\tMove temp file: [mv $d_temp.sitechan,$d_new.sitechan]") ;
+        elog_notify("Move temp file: [mv $d_temp.sitechan,$d_new.sitechan]") ;
         unless ( $options{'n'} ) {
             move("$d_temp.sitechan","$d_new.sitechan") or
             log_die("ERROR: Cannot move file $d_temp.sitechan to $d_new.sitechan");

--- a/anf/bin/utility/dbwfserver_ta_setup/dbwfserver_ta_setup.xpl
+++ b/anf/bin/utility/dbwfserver_ta_setup/dbwfserver_ta_setup.xpl
@@ -3,221 +3,99 @@
 #       script to subset all sitechan
 #       tables for TA dbwfserver instances
 #
-#   author: Juan C. Reyes
-#   email:  reyes@ucsd.edu
-#   No BRTT support
+#   Original author: Juan C. Reyes
+#   Modifications by: Geoff Davis
+#   email:  support@anf.ucsd.edu
 #
 
-use archive ;
-use sysinfo ;
-use Datascope ;
-use File::Copy ;
-use Pod::Usage "pod2usage" ;
-use Getopt::Std "getopts" ;
-use IPC::Cmd qw/can_run/ ;
-
-
-select STDOUT; $| = 1 ;
-select STDERR; $| = 1 ;
-
-#
-#
-#   THE VALUES OF THE CONSTANTS CAN BE
-#   MODIFY BUT THE NAMES ARE EXPECTED
-#   TO BE IMMUTABLE. THEY ARE DYNAMICALLY
-#   BUILD DURING EXECUTION OF SCRIPT !!!!!
-#
-#
+use warnings;
+use strict;
+use archive qw/savemail sendmail/;
+use sysinfo;
+use Datascope;
+use Data::Dumper;
+use File::Copy;
+use File::Basename 'basename';
+use Pod::Usage 'pod2usage';
+use Getopt::Std 'getopts';
+use IPC::Cmd 'can_run';
 
 #
-# RealTime system
+# CONFIG
 #
-$rt_path = "/export/home/rt/rtsystems/dbwfserver/" ;
+our $PROGNAME = basename($0);
+our $PFNAME = $PROGNAME;
+our $PF_REVISION_TIME = 1579029286;
+our @DBPATH_SUBKEYS = qw/db temp new/;
 
-#
-# AOC testing. TESTING SYSTEMS ONLY
-#
-$aoc_db = "db/dbwfserver_aoc_test" ;
-$aoc_temp = "db/dbwfserver_temp" ;
-$aoc_new = "db/dbwfserver_aoc_test" ;
+our %options; # Command line options
+our $params;  # Pointer to contents of the parameter file
+our $dbadd;   # path to dbadd executable
 
-#
-#Seismic database
-#
-$ta_db = "db/dbwfserver_usarray" ;
-$ta_temp = "db/dbwfserver_temp" ;
-$ta_new = "db/dbwfserver_usarray" ;
+sub log_die {
+    my $msg = shift;
+    our %options;
 
-#
-#SOH database
-#
-$soh_db = "db/dbwfserver_status" ;
-$soh_temp = "db/dbwfserver_temp" ;
-$soh_new = "db/dbwfserver_status" ;
-
-#
-#INFRAMET database
-#
-$inframet_db = "db/dbwfserver_inframet" ;
-$inframet_temp = "db/dbwfserver_tmp" ;
-$inframet_new = "db/dbwfserver_inframet" ;
-
-#
-#ANZA database
-#
-$anza_db = "db/dbwfserver_anza" ;
-$anza_temp = "db/dbwfserver_tmp" ;
-$anza_new = "db/dbwfserver_anza" ;
-
-#
-#CEUSN database
-#
-$ceusn_db = "db/dbwfserver_ceusn" ;
-$ceusn_temp = "db/dbwfserver_tmp" ;
-$ceusn_new = "db/dbwfserver_ceusn" ;
-
-#
-#CEUSN INFRAMET database
-#
-$ceusninframet_db = "db/dbwfserver_ceusn_inframet" ;
-$ceusninframet_temp = "db/dbwfserver_tmp" ;
-$ceusninframet_new = "db/dbwfserver_ceusn_inframet" ;
-
-#
-#CEUSN INFRAMET database
-#
-$ceusnsoh_db = "db/dbwfserver_ceusn_soh" ;
-$ceusnsoh_temp = "db/dbwfserver_tmp" ;
-$ceusnsoh_new = "db/dbwfserver_ceusn_soh" ;
-#
-#  Program setup
-#
-$start = now() ;
-$parent = $$ ;
-
-if ( ! getopts('rfnhm:') || @ARGV != 0 ) {
-    pod2usage({-exitval => 2, -verbose => 2}) ;
-}
-
-pod2usage({-exitval => 2, -verbose => 2}) if $opt_h ;
-
-
-elog_init($0,@ARGV) ;
-
-if ( $opt_f and ! $opt_m ) {
-    elog_die("ERRO: Need flag '-m email' to use the '-f' option") ;
-}
-
-savemail() if $opt_f ;
-
-elog_notify('') ;
-elog_notify("$0 @ARGV") ;
-elog_notify("Starting at ".strydtime($start)." on ".my_hostname()) ;
-elog_notify('') ;
-
-if ( $opt_n ) {
-    elog_notify("**********************") ;
-    elog_notify("**** DRY/NULL RUN ****") ;
-    elog_notify("**********************") ;
-}
-
-#
-# We need dbadd
-#
-$dbadd = can_run('dbadd') or log_die("dbadd missing on PATH:".path()) ;
-
-#
-# Verify Database
-#
-foreach $d ( qw/anza inframet soh ta ceusn ceusninframet ceusnsoh/ ){
-    $d_db = ${$d."_db"} ;
-    log_die("Can't find DB: $d_db.wfdisc") unless -f "$d_db.wfdisc" ;
-}
-
-
-#
-# Run external commands
-#
-foreach $d ( qw/aoc anza inframet soh ta ceusn ceusninframet ceusnsoh/ ){
-
-    #
-    # Build temp vars
-    #
-    $d_db = ${$d."_db"} ;
-    $d_new = $rt_path . ${$d."_new"} ;
-    $d_temp = $rt_path . ${$d."_temp"} ;
-
-    #
-    # Clean old temp files
-    #
-    elog_notify("\tClean temp tables for $d") ;
-
-    remove_file( "${d_temp}.lastid" ) ;
-    remove_file( "${d_temp}.sitechan" ) ;
-
-    #
-    # Build sitechan table
-    #
-    elog_notify("$dbadd -a $d_db.wfdisc $d_temp.sitechan") ;
-    run("$dbadd -a $d_db.wfdisc $d_temp.sitechan  >& /dev/null") unless $opt_n ;
-
-    #
-    # Move sitechan table
-    #
-    elog_notify("\tMove temp file: [mv $d_temp.sitechan,$d_new.sitechan]") ;
-    unless ( $opt_n ) {
-        log_die("ERROR: Cannot move file $d_temp.sitechan to $d_new.sitechan") 
-                unless move("$d_temp.sitechan","$d_new.sitechan") ;
+    # If we are supposed to send email, Start savemail unless a savemail
+    # session was started already. Otherwise, output mysteriously
+    # disappears and random tempfiles get left around.
+    if ($options{'m'}){
+        savemail() unless $options{'f'};
+        elog_complain($msg);
+        sendmail('dbwfserver_ta_setup: ERROR',$options{'m'}) if $options{'m'};
     }
 
-    #
-    # Remove lastid file
-    #
-    remove_file( "${d_temp}.lastid" ) ;
 
-    elog_notify("") ;
+
+    elog_die($msg);
 
 }
 
-restart_systems() if $opt_r ;
+sub _validate_wfdisc_exists($) {
+    # Given a db_path, verify that the associated Datascope wfdisc table exists
+    my $db_path = shift;
+    my $wfdisc_filename = $db_path . '.wfdisc';
+    log_die("Can't find DB: " . $wfdisc_filename) unless -f $wfdisc_filename;
+}
 
-$end = now() ;
-$run_time_str = strtdelta($end - $start) ;
-$start = strydtime($start) ;
-$end = strydtime($end) ;
-
-elog_notify("\n\n----------------- END -----------------\n\n") ;
-elog_notify("Start: $start End: $end") ;
-elog_notify("Runtime: $run_time_str") ;
-
-
-
-sendmail('dbwfserver_ta_setup: Success',$opt_m) if $opt_m and $opt_f ;
-
-exit ;
-
+sub _validate_dbpath_subkeys($) {
+    # Verify that the DBPATH_SUBKEYS exist for a given $db_name in
+    # $params->{database_paths}
+    my $db_name = shift;
+    our $params;
+    our @DBPATH_SUBKEYS;
+    foreach my $key_name ( @DBPATH_SUBKEYS ) {
+        unless (exists($params->{'database_paths'}{$db_name}{$key_name})) {
+            log_die(
+                'Parameter file key ' . $key_name . ' for database ' .\
+                $db_name . " is missing. Can't continue.");
+        }
+    }
+}
 
 sub restart_systems{
+    # Restart the real-time system in $RTSYSTEM_DIRECTORY with rtkill
 
-    my @procs = () ;
-    my $name ;
-    my $fh ;
+    my @procs = ();
+    my $name;
+    my $fh;
+    our %options;
+    our $params;
 
-    elog_notify("Restart rtexec tasks: [${rt_path}rtexec.pf]") ;
+    my $rtdir = $params->{'rtsystem_directory'};
+    my $pf_file = $rtdir . '/rtexec.pf';
+    elog_notify("Restart rtexec tasks: [$pf_file]") ;
 
     #
     # Change to realtime directory
     #
-    log_die("ERROR: Cannot chdir to $rt_path") unless
-            chdir $rt_path ;
+    chdir $rtdir or log_die("ERROR: Cannot chdir to $rtdir");
 
 
     elog_notify("rtkill -l =>") ;
-    open($fh, '-|', 'rtkill -l')
-        or log_die("ERROR: rtkill -l => $!") ;
+    open($fh, '-|', 'rtkill -l') or log_die("ERROR: rtkill -l => $!") ;
 
     while ($name = <$fh>) {
-
         elog_notify("\t$name") ;
         next if $name =~ /^(\s*)$/ ;
         $name =~ /^\s*(\w*)\s*(on)\s*$/ ;
@@ -225,7 +103,6 @@ sub restart_systems{
             push ( @procs, $1 ) ;
             elog_notify("GOT PROC: [$1]") ;
         }
-
     }
 
     close($fh);
@@ -234,74 +111,174 @@ sub restart_systems{
     #
     # Restart rtsystem
     #
-    foreach $d ( @procs ){
-
-        elog_notify("\tRestart: [$d]") ;
-        run("rtkill -r $d") unless $opt_n ;
-
+    foreach my $d ( @procs ){
+        elog_notify("\tRestart: [$d]");
+        my_run("rtkill -r $d") unless $options{'n'};
     }
-
 }
 
 
-sub remove_file{
+sub remove_table_temp_file{
+    my $table = shift;
+    our $options;
 
-    my $table = shift ;
+    elog_notify("\tRemove temp file: [$table]");
+    return 0 if $options{'n'};
 
-    elog_notify("\tRemove temp file: [$table]") ;
-    return if $opt_n ;
-
-    if ( -f $table ) {
-
-        log_die("ERROR: Cannot remove temp file $table") unless
-                unlink($table) ;
-
+    if ( -f $table ){
+        unlink($table) or log_die("ERROR: Cannot remove temp file $table");
     }
-
+    return 0;
 }
 
-sub run{
+sub my_run{
     my $cmd = shift ;
+    our %options;
 
-    elog_notify("\tRunning cmd: [$cmd]") ;
-    return if $opt_n ;
+    elog_notify("\tRunning cmd: [$cmd]");
+    return if $options{'n'};
 
-    system($cmd) == 0 or log_die("ERROR in system call: [$cmd]") ;
+    system($cmd) == 0 or log_die("ERROR in system call: [$cmd]");
 
-    if ($? == -1) {
-
-        log_die("failed to execute: [$cmd] => $!") ;
-
+    if ($? == -1){
+        log_die("failed to execute: [$cmd] => $!");
     } elsif ($? & 127) {
-
         log_die("child died with signal %d, %s coredump",
             ($? & 127),
-            ($? & 128) ? 'with' : 'without') ;
-
+            ($? & 128) ? 'with' : 'without');
     }
     else {
+        elog_notify("\t\tchild exited with value %d", $? >> 8);
+    }
+    return;
+}
 
-        elog_notify("\t\tchild exited with value %d", $? >> 8) ;
+sub main {
+    #
+    #  Program setup
+    #
+    select STDOUT; $| = 1 ;
+    select STDERR; $| = 1 ;
+    my $start = now() ;
+    my $parent = $$ ;
+    our %options;
+    our $params;
+    our ($PFNAME, $PF_REVISION_TIME);
+
+    if ( ! getopts('rfnhm:', \%options) || @ARGV != 0 ) {
+        pod2usage({-exitval => 2, -verbose => 2}) ;
+    }
+
+    pod2usage({-exitval => 2, -verbose => 2}) if $options{'h'};
+
+    elog_init($0,@ARGV) ;
+
+    # Load parameter file
+    pfrequire($PFNAME, $PF_REVISION_TIME);
+    $params = pfget($PFNAME, "");
+
+    # Parse command line options
+    if ($options{'f'} and ! $options{'m'}) {
+        elog_die("ERROR: Need flag '-m email' to use the '-f' option");
+    }
+
+    savemail() if $options{'f'};
+
+    elog_notify('') ;
+    elog_notify("$0 @ARGV") ;
+    elog_notify("Starting at ".strydtime($start)." on ".my_hostname()) ;
+    elog_notify('') ;
+
+    if ($options{'n'}) {
+        elog_notify("**********************") ;
+        elog_notify("**** DRY/NULL RUN ****") ;
+        elog_notify("**********************") ;
+    }
+
+    #
+    # We need dbadd
+    #
+    $dbadd = can_run('dbadd') or log_die("dbadd missing from PATH:".path()) ;
+
+    #
+    # Verify Database paths are set and that the source databases exist
+    #
+    foreach my $db_name (keys ($params->{'database_paths'})){
+        elog_debug("validating $db_name subkeys\n");
+        _validate_dbpath_subkeys($db_name);
+        my $db_path = $params->{'database_paths'}{$db_name}{'db'};
+        elog_debug("validating $db_name wfdisc exists\n");
+        _validate_wfdisc_exists($db_path);
+    }
+
+    #
+    # Run external commands
+    #
+    foreach my $d (keys($params->{'database_paths'})){
+
+        print "GOT HERE\n";
+
+        #
+        # Build temp vars
+        #
+        my $d_db = $params->{'database_paths'}{$d}{'db'};
+        my $d_new = $params->{'database_paths'}{$d}{'new'};
+        my $d_temp = $params->{'database_paths'}{$d}{'temp'};
+
+        #
+        # Clean old temp files
+        #
+        elog_notify("\tClean temp tables for $d") ;
+
+        remove_table_temp_file( "${d_temp}.lastid" ) ;
+        remove_table_temp_file( "${d_temp}.sitechan" ) ;
+
+        #
+        # Build sitechan table
+        #
+        elog_notify("$dbadd -a $d_db.wfdisc $d_temp.sitechan") ;
+        my_run("$dbadd -a $d_db.wfdisc $d_temp.sitechan  >& /dev/null") unless $options{'n'} ;
+
+        #
+        # Move sitechan table
+        #
+        elog_notify("\tMove temp file: [mv $d_temp.sitechan,$d_new.sitechan]") ;
+        unless ( $options{'n'} ) {
+            move("$d_temp.sitechan","$d_new.sitechan") or
+            log_die("ERROR: Cannot move file $d_temp.sitechan to $d_new.sitechan");
+        }
+
+        #
+        # Remove lastid file
+        #
+        remove_table_temp_file( "${d_temp}.lastid" ) ;
+
+        elog_notify("") ;
 
     }
 
-    return ;
+    restart_systems() if $options{'r'} ;
 
+    my $end = now() ;
+    my $run_time_str = strtdelta($end - $start) ;
+    $start = strydtime($start) ;
+    $end = strydtime($end) ;
+
+    elog_notify("\n\n----------------- END -----------------\n\n") ;
+    elog_notify("Start: $start End: $end") ;
+    elog_notify("Runtime: $run_time_str") ;
+
+
+
+    sendmail('dbwfserver_ta_setup: Success',$options{'m'}) if $options{'m'} and $options{'f'} ;
+
+    return (0);
 }
 
-sub log_die {
-    my $msg = shift ;
-
-    savemail() unless $opt_f ;
-
-    elog_complain($msg) ;
-
-    sendmail('dbwfserver_ta_setup: ERROR',$opt_m) if $opt_m ;
-
-    elog_die($msg) ;
-
-}
-
+#
+# Run main()
+#
+exit(main(@ARGV));
 
 __END__
 
@@ -317,7 +294,7 @@ dbwfserver_ta_setup [-h] [-n] [-d] [-f] [-m email]
 
 =head1 SUPORT
 
-No BRTT support == contact Juan Reyes <reyes@ucsd.edu>
+No BRTT support == contact ANF Support <support@anf.ucsd.edu>
 
 =head1 ARGUMENTS
 
@@ -325,23 +302,23 @@ Recognized flags:
 
 =over 2
 
-=item B<-h> 
+=item B<-h>
 
 Produce this documentation
 
-=item B<-n> 
+=item B<-n>
 
 Test  mode/dry  run.  Does not delete, copy or move  any file or folder.
 
-=item B<-r> 
+=item B<-r>
 
 Restart all running procs on the real-time system at the end of the script.
 
-=item B<-f> 
+=item B<-f>
 
-Force email at end of script. The default is to send emails only on errors. Needs -m flag. 
+Force email at end of script. The default is to send emails only on errors. Needs -m flag.
 
-=item B<-m email> 
+=item B<-m email>
 
 Email this address in case of error or if -f flag is set.
 
@@ -350,31 +327,35 @@ Email this address in case of error or if -f flag is set.
 
 =head1 DESCRIPTION
 
-dbwfserver_ta_setup will build new sitechan tables for the Inframet, Seismic and SOH instances of the 
-WaveformServers of the TA daatasets and one for ANZA. This should run every day so any new sta:chan entry 
-on the wfdisc will be recognized by the software. After creating the new sitechan tables the software will
-move them to the production paths and then restart the servers. By default the script will only email
-on errors. If the -f flag is set then an email will be produced on every run.
+dbwfserver_ta_setup uses the dbadd(1) command to build new sitechan tables for
+the Inframet, Seismic and SOH instances of the WaveformServers of the TA
+daatasets and one for ANZA. This should run every day so any new sta:chan entry
+in the source database wfdisc will be recognized by the software. After
+creating the new sitechan tables the software will move them to the production
+paths and then restart the servers. By default the script will only email on
+errors. If the -f flag is set then an email will be produced on every run.
 
 =head1 BUGS AND CAVEATS
 
-All paths are hardcoded in the script. 
-
-The -r option will run the command rtkill -l and will parse for 
+The -r option will run the command rtkill -l and will parse for
 all lines with the "on" status. Then it will restart all of those
 procs with the rtkill command.
 
 =head1 ENVIRONMENT
 
-needs to have sourced $ANTELOPE/setup.csh.
+The Antelope environment must be set correctly.
 
-=head1 AUTHOR
+=head1 AUTHORS
 
-Juan C. Reyes <reyes@ucsd.edu>
+Juan C. Reyes
+Geoff Davis
+<support@anf.ucsd.edu>
+
 
 =head1 SEE ALSO
 
-Perl(1).
+Perl(1)
+dbadd(1)
 
 =cut
-
+# vim:ft=perl


### PR DESCRIPTION
dbwfserver_ta_setup has been failing due to hard coded database paths. Additionally, the version in use was copied into the real-time system path, because editing the source file was apparently too many steps.

This change allows the command to use a parameter file, and makes it work on the demo database.

Note that the parameter file in  the archive does not match what is in production any more, by design.