### PR TITLE
Fix ANF python library directory for site-packages

### DIFF
--- a/anf/data/python/template/xpy.contrib.id
+++ b/anf/data/python/template/xpy.contrib.id
@@ -10,6 +10,6 @@ signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 sys.path.append(os.environ['ANTELOPE'] + "/contrib/data/python")
 sys.path.append(os.environ['ANTELOPE'] + "/data/python")
-site.addsitedir(os.environ['ANF'] + "/lib/python$python_mainversion")
+site.addsitedir(os.environ['ANF'] + "/lib/python$python_mainversion/site-packages")
 sys.path.append(os.environ['ANF'] + "/data/python")
 

--- a/anf/data/python/template/xpy.contrib.id
+++ b/anf/data/python/template/xpy.contrib.id
@@ -10,6 +10,6 @@ signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 sys.path.append(os.environ['ANTELOPE'] + "/contrib/data/python")
 sys.path.append(os.environ['ANTELOPE'] + "/data/python")
-site.addsitedir(os.environ['ANF'] + "/lib/python")
+site.addsitedir(os.environ['ANF'] + "/lib/python$python_mainversion")
 sys.path.append(os.environ['ANF'] + "/data/python")
 


### PR DESCRIPTION
3rd party modules have long installed themselves to $ANF.

Python as distributed by BRTT has changed the explicit subdir under which the modules are actually installed.

With Antelope 5.7 and later, we can rely on them being in `$ANF/lib/python*/site-packages`