### PR TITLE
Force decode as ascii, error if it doesn't work.

### DIFF
--- a/anf/bin/import/xi202_import/orb_serials.py
+++ b/anf/bin/import/xi202_import/orb_serials.py
@@ -161,21 +161,26 @@ class ORBserials:
                     self.logging.info("%s %s:%s" % (srcname, Exception, e))
 
                 else:
-                    orbpkt_pf = stock.ParameterFile()
-                    orbpkt_pfdata = pktbuf.rstrip(b"\x00").lstrip(b"\xff").decode()
-                    orbpkt_pf.pfcompile(orbpkt_pfdata)
-
                     try:
-                        orbpkt_dataloggers = orbpkt_pf["q3302orb.pf"]["dataloggers"]
-                        self.logging.debug(orbpkt_dataloggers)
+                        orbpkt_pf = stock.ParameterFile()
+                        orbpkt_pfdata = (
+                            pktbuf.rstrip(b"\x00")
+                            .lstrip(b"\xff")
+                            .decode("ascii", "strict")
+                        )
+                        orbpkt_pf.pfcompile(orbpkt_pfdata)
 
-                    except TypeError:
-                        """BRTT bindings throw a TypeError if the pf object is
-                        invalid."""
-                        self.logging.error("Bad PF stash packet")
-                    except KeyError:
-                        self.logging.warning(
-                            "No information in stash packet for %s" % srcname
+                        try:
+                            orbpkt_dataloggers = orbpkt_pf["q3302orb.pf"]["dataloggers"]
+                            self.logging.debug(orbpkt_dataloggers)
+
+                        except KeyError:
+                            self.logging.warning(
+                                "No information in stash packet for " + srcname
+                            )
+                    except UnicodeDecodeError as e:
+                        self.logging.error(
+                            "Could not decude packet as ASCII for " + srcname
                         )
 
                     for dl in orbpkt_dataloggers:

--- a/anf/bin/import/xi202_import/xi202_import.1
+++ b/anf/bin/import/xi202_import/xi202_import.1
@@ -73,7 +73,8 @@ Mapping for each parameter found on the Document to a valid channel name in Ante
 
 
 .SH "AUTHOR"
-Juan Reyes <reyes@ucsd.edu>
+Juan Reyes
+Geoff Davis
 
 .SH "SUPPORT"
-Contributed: NO BRTT support -- please contact author at reyes@ucsd.edu
+Contributed: NO BRTT support -- please contact author at support@ucsd.edu


### PR DESCRIPTION
xi202_import crashes if the Antelope Pf routines can't read a badly formatted packet.

This change forces unicode decoding to fail if it encounters non-ASCII characters, as this is typically a sign of a corrupt packet.

For TA-1668