### PR TITLE
Resolve Trmath warnings

### DIFF
--- a/anf/data/python/seispy/trmath.c
+++ b/anf/data/python/seispy/trmath.c
@@ -1,4 +1,10 @@
-#include <Python.h>
+#include "Python.h"
+#if PY_MAJOR_VERSION >= 3
+#define Num_FromLong PyLong_FromLong
+#else
+#define Num_FromLong PyInt_FromLong
+#endif
+
 #include <math.h>
 
 static PyObject *
@@ -18,7 +24,7 @@ trmath_tr_float_to_int(PyObject *self, PyObject *args)
 
     for (i = 0; i < trl; i++ ){
         temp = PyNumber_TrueDivide(PyList_GetItem(tr, i), lsc);
-        PyList_SetItem(tr, i, PyInt_FromLong((long) round(PyFloat_AsDouble(temp))));
+        PyList_SetItem(tr, i, Num_FromLong((long) round(PyFloat_AsDouble(temp))));
         Py_DECREF(temp);
     }
 

--- a/anf/lib/makerules/darwin-intel.in
+++ b/anf/lib/makerules/darwin-intel.in
@@ -1,6 +1,7 @@
 
 CFLAGS += -I$(DEST)/include
 COFLAGS += -I$(DEST)/include
+CPPFLAGS += -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
 FFLAGS += -I$(DEST)/include
 LDPATH += -L$(DEST)/lib -L$(DEST)/static
 LDRUN += -R$(DEST)/lib


### PR DESCRIPTION
Trmath isn't building in Python3. This resolves several of these issues.